### PR TITLE
add escaped characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea/
 node_modules/
 .lone/
 npm-debug.log

--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@
  * @returns {string} The object key.
  */
 module.exports = function(path){
-  return path.replace(/^\//, '').replace(/\//g, '.');
+  return path.replace(/^\//, '').replace(/\//g, '.').replace(/~1/g, '/').replace(/~0/g, '~');
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,5 +6,6 @@ describe('jsonpath to dot', function(){
     assert.equal(toDot('/tags'), 'tags');
     assert.equal(toDot('/tags/1'), 'tags.1');
     assert.equal(toDot('/tags/blah'), 'tags.blah');
+    assert.equal(toDot('/foo~1bar~0'), 'foo/bar~');
   });
 });


### PR DESCRIPTION
~0 <=> ~and ~1 <=> /
Adds test and replacements to be ok with the rfc6901 See [jsonpatch](http://jsonpatch.com/)

> you need to refer to a key with ~ or / in its name, you must escape the characters with \~0 and \~1 respectively. For example, to get "baz" from { "foo/bar\~": "baz" } you’d use the pointer /foo\~1bar\~0.
